### PR TITLE
Update appium-doctor URL and installation command

### DIFF
--- a/Automation/Mobile/Appium/Appium setup.md
+++ b/Automation/Mobile/Appium/Appium setup.md
@@ -43,7 +43,7 @@ Appium 2.x does not include drivers by default. They have to be installed separa
 1. Install Appium
     - `npm install -g appium@next`
 2. Install Appium Doctor
-   - `npm install -g appium-doctor`
+   - `npm install -g @appium/doctor`
 3. Install xcuitest (iOS) driver
    - `appium driver install xcuitest`
 4. Install uiautomator2 (Android) driver

--- a/Automation/Mobile/Appium/Troubleshooting Appium.md
+++ b/Automation/Mobile/Appium/Troubleshooting Appium.md
@@ -4,7 +4,7 @@
 
 You just installed Appium (Server or Desktop) and you try to run it but nothing happens. Before you ask Google for help, run `appium-doctor` and make sure the necessary dependencies are ok.
 
-[Appium doctor](https://github.com/appium/appium-doctor)
+[Appium doctor](https://github.com/appium/appium/tree/master/packages/doctor)
 
 ![troubleshooting_appium_appium_doctor.png](/img/troubleshooting_appium_appium_doctor.png)
 


### PR DESCRIPTION
As the `appium-doctor` project is deprecated ([see here](https://www.npmjs.com/package/appium-doctor)), I updated the articles with:
- The new command for installing it. `npm install -g @appium/doctor`
- The new URL to the appium-doctor package. https://github.com/appium/appium/tree/master/packages/doctor

The command used in Terminal for running it stayed the same. 😄 