### PR TITLE
Update SSH instructions in git articles

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="5bded075-01ea-4006-b2f6-eeeaa56a6ead" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2LY7cFlFBEucVAsr41JC825kDTR" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="5bded075-01ea-4006-b2f6-eeeaa56a6ead" name="Changes" comment="" />
+      <created>1676036240011</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1676036240011</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="update-appium-git-articles" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
+          </value>
+        </entry>
+      </map>
+    </option>
+    <option name="RECENT_FILTERS">
+      <map>
+        <entry key="Branch">
+          <value>
+            <list>
+              <RecentGroup>
+                <option name="FILTER_VALUES">
+                  <option value="update-appium-git-articles" />
+                </option>
+              </RecentGroup>
+            </list>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/Automation/Mobile/Appium/iOS setup.md
+++ b/Automation/Mobile/Appium/iOS setup.md
@@ -28,8 +28,8 @@ You can set up the iOS configuration in two ways:
 3. Choose the Application template (e.g. **Single View App**) and click **Next**
 4. Enter product name
    - E.g. _Demo application_
-5. Click **Add account** and use **your personal** iCloud account
-6. Click **Team** dropdown and choose **your personal** account
+5. Click **Add account** and use **your personal Infinum** iCloud account
+6. Click **Team** dropdown and choose **your personal Infinum** account
 7. Make sure the _Automatically manage signing_ option is checked
 8. Enter Organization Identifier and click **Next**
    - E.g. _com.appiumtest.demo-application_

--- a/Automation/Mobile/Appium/iOS setup.md
+++ b/Automation/Mobile/Appium/iOS setup.md
@@ -61,10 +61,10 @@ In that case, do the following:
 3. Click the _WebDriverAgent_ from the Project navigator
 4. Open **Signing & Capabilities** tab
 5. Choose _WebDriverAgentLib_ from the **Targets** section
-6. Manually choose **your personal account** under _Team_ 
+6. Manually choose **your personal Infinum account** under _Team_ 
    - Wait for the signing process to finish
 7. Next, choose _WebDriverAgentRunner_ from the **Targets** section
-8. Again, manually choose **your personal account** under _Team_ 
+8. Again, manually choose **your personal Infinum account** under _Team_ 
    - Wait for the signing process to finish
    - The signing will probably fail due to the wrong Bundle identifier. Don't worry, we'll fix that
 9. Click the **Build Settings** tab

--- a/Tools/Version Control Systems/Access token and SSH keys.md
+++ b/Tools/Version Control Systems/Access token and SSH keys.md
@@ -4,26 +4,26 @@
 
 To make the git commands *pull* / *push* / *clone* work with two-factor authentication (2FA), you need a personal access token which you will then use for authentication when performing *clone* / *pull* / *push* operations, instead of the user password.
 
-1. Go to the *GitHub*
+1. Go to *GitHub*.
 
-2. Click the profile image and select *Settings*
+2. Click the profile image and select *Settings*.
 
-3. Select *Developer settings* in the menu on the left-hand side
+3. Select *Developer settings* in the menu on the left-hand side.
 
-4. Select *Personal access tokens* in the menu on the left-hand side
+4. Select *Personal access tokens* in the menu on the left-hand side.
 
-5. Click the *Generate new token* button
+5. Click the *Generate new token* button.
 
-6. Confirm your GitHub password, if prompted
+6. Confirm your GitHub password, if prompted.
 
-7. In the 'Note' field type in the token name
+7. In the 'Note' field, type in the token name.
 
-8. Select the *scopes* (permissions) for the access token
- - Select *repo* to have full control of private repositories
+8. Select the *scopes* (permissions) for the access token.
+ - Select *repo* to have full control of private repositories.
 
-9. Click the *Generate token* button
+9. Click the *Generate token* button.
 
-10. Make sure to copy the token because you won’t be able to see it again
+10. Make sure to copy the token because you won’t be able to see it again.
 
 Source: [https://webkul.com/blog/github-push-with-two-factor-authentication/]()
 
@@ -31,23 +31,24 @@ Source: [https://webkul.com/blog/github-push-with-two-factor-authentication/]()
 
 ## How to use the access token
 
-1. Open the terminal and position to a folder in which you want to put your new project (e.g. Documents folder)
+1. Open the terminal and position to a folder in which you want to put your new project (e.g., Documents folder).
 
 	`cd ~/Documents`
 
-2. Clone the repository to your machine
+2. Clone the repository to your machine.
 
 	`git clone https://github.com/username/repository.git`
 
-3. Enter your GitHub *username* when prompted
+3. Enter your GitHub *username* when prompted.
 
-4. Don't use your Github password when prompted, instead enter the generated access token
+4. Don't use your GitHub password when prompted, instead enter the generated access token.
 
-5. Wait for the cloning to finish and continue to work on the project locally
+5. Wait for the cloning to finish and continue to work on the project locally.
 
 
 ## How to connect to GitHub using the SSH protocol and ssh-agent
-By default Git connects to remotes using the HTTPS protocol which requires you to enter your username and password every time you run a command such as *git pull* or *git push*.
+
+By default, Git connects to remotes using the HTTPS protocol which requires you to enter your username and password every time you run a command such as *git pull* or *git push*.
 
 Using the SSH protocol, you can connect and authenticate to remote servers and services. With SSH keys, you can connect to GitHub without supplying your username or password with each visit.
 
@@ -57,18 +58,19 @@ First, check whether you have any existing SSH keys. To do this, open the termin
 
 If you don't have an existing public and private key pair, then generate a new SSH key.
  
-1. Open the terminal
+1. Open the terminal.
  
 2. Create a new SSH key with the provided email as a label by running the following command (substituting in your GitHub email address):
 
-	`ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`
+	`ssh-keygen -t ed25519 -C "your_email@example.com"`
  
-3. Press Enter when prompted to "*Enter a file in which to save the key*"  to accept the default file location
+3. Press Enter when prompted to "*Enter a file in which to save the key*" to accept the default file location.
  
-4. Enter a secure passphrase when prompted
+4. Enter a secure passphrase when prompted.
  
 
 ### How to add SSH key to ssh-agent
+
 If you don't want to re-enter your passphrase every time you use your SSH key, you can add your key to the ssh-agent (a helper program that runs in the background while you are logged in to the system and manages your SSH keys and their passphrases).
  
 1. Start the ssh-agent in the background
@@ -85,35 +87,36 @@ If you don't want to re-enter your passphrase every time you use your SSH key, y
 	Host *
   	AddKeysToAgent yes
   	UseKeychain yes
-  	IdentityFile ~/.ssh/id_rsa
+  	IdentityFile ~/.ssh/id_ed25519
   	```
 
-3. Add your SSH private key to the ssh-agent and store your passphrase in the keychain. If you created your key with a different name, or if you are adding an existing key that has a different name, replace `id_rsa` in the command with the name of your private key file:
+3. Add your SSH private key to the ssh-agent and store your passphrase in the keychain. If you created your key with a different name, or if you are adding an existing key that has a different name, replace `id_ed25519` in the command with the name of your private key file:
 
-	`ssh-add -K ~/.ssh/id_rsa`
+	`ssh-add --apple-use-keychain ~/.ssh/id_ed25519`
 
-4. Enter the passphrase to add your identity
+4. Enter the passphrase to add your identity.
 
-5. Add the SSH key to your GitHub account (see How to add SSH key to your GitHub account)
+5. Add the SSH key to your GitHub account (see "How to add SSH key to your GitHub account").
 
 
 ### How to add SSH key to your GitHub account
-To configure your Github account to use your new (or existing) SSH key, you'll also need to add it to your GitHub account (after adding a new SSH key to your GitHub account, you can reconfigure any local repositories to use SSH).
+
+To configure your GitHub account to use your new (or existing) SSH key, you'll also need to add it to your GitHub account (after adding a new SSH key to your GitHub account, you can reconfigure any local repositories to use SSH).
  
 1. Open the terminal and run the following command to copy the SSH key to your clipboard (make sure that you don’t copy any whitespace while copying the public key’s content):
 
-	`pbcopy < ~/.ssh/id_rsa.pub`
+	`pbcopy < ~/.ssh/id_ed25519.pub`
 
-2. Open *Settings* on your Github page
+2. Open *Settings* on your GitHub page.
 
-3. Select *SSH and GPG keys* in the menu on the left-hand side
+3. Select *SSH and GPG keys* in the menu on the left-hand side.
 
-4. Click the *New SSH key* button
+4. Click the *New SSH key* button.
 
-5. In the *Title* field type in a descriptive label for the new key. For example, if you're using your work Mac, you could call it "*work-Mac*"
+5. In the 'Title' field type in a descriptive label for the new key. For example, if you're using your work Mac, you could call it "*work-Mac*".
 
-6. In the ‘Key’ field paste your SSH key
+6. In the 'Key' field, paste your SSH key.
 
-7. Click the Add SSH key button
+7. Click the *Add SSH key* button.
 
-8. Confirm your GitHub password, if prompted
+8. Confirm your GitHub password, if prompted.


### PR DESCRIPTION
Changes:
- Updated the SSH instructions according to the [latest instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key). `ssh_rsa` was replaced by `id_ed25519`. Alongside that, I ran the text through Hemmingway/Grammarly and made some small changes.
- Small update related to Appium iOS setup to specify more precisely which iCloud account to use.