### PR TITLE
Add article Playwright for Python

### DIFF
--- a/Automation/Web/Get started with Playwright for Python.md
+++ b/Automation/Web/Get started with Playwright for Python.md
@@ -26,7 +26,7 @@ This is a short and simple guide to quickly get started with Playwright for Pyth
 5. Run the test
    * On default (headless) browser:
      * `python3 -m pytest test_homepage.py`
-   * On specific (headed) browser
+   * On specific (headed) browser:
      * `python3 -m pytest test_home_page.py --browser firefox –headed`
 
 

--- a/Automation/Web/Get started with Playwright for Python.md
+++ b/Automation/Web/Get started with Playwright for Python.md
@@ -66,4 +66,4 @@ def test_homepage(page: Page):
 * [Playwright for Python](https://playwright.dev/python/docs/intro)
 * [Playwright GitHub](https://github.com/microsoft/playwright)
 * [pytest-playwright plugin](https://pypi.org/project/pytest-playwright)
-* [pytest](https://docs.pytest.org/en/7.2.x/) 
+* [pytest](https://docs.pytest.org/en/7.2.x) 

--- a/Automation/Web/Get started with Playwright for Python.md
+++ b/Automation/Web/Get started with Playwright for Python.md
@@ -1,0 +1,69 @@
+## What is Playwright?
+
+Playwright is a test automation tool for Web testing. It supports testing on various browsers in both headed and headless mode. 
+You can write tests in JavaScript / TypeScript, C#, Java and Python. Depending on your language of choice, the setup slightly differs.
+
+This is a short and simple guide to quickly get started with Playwright for Python.
+
+
+## Requirements
+
+* Python 3.7 or newer.
+* Check [Playwright troubleshooting](https://playwright.dev/python/docs/troubleshooting) for more details.
+
+
+## Setup
+
+1. Create a new PyCharm project 
+   * Create and activate a [virtual environment](https://infinum.com/handbook/qa/automation/python/virtual-environment)
+2. Install [pytest-playwright](https://pypi.org/project/pytest-playwright/) plugin 
+   * `pip install pytest-playwright`
+3. Install browsers 
+   * `playwright install`
+4. Create a test file within the current working directory or a sub-directory
+   * File name e.g.: `test_homepage.py `
+   * See example test below
+5. Run the test
+   * On default (headless) browser:
+     * `python3 -m pytest test_homepage.py`
+   * On specific (headed) browser
+     * `python3 -m pytest test_home_page.py --browser firefox –headed`
+
+
+## Example
+
+```python
+import re
+
+from playwright.sync_api import Page, expect
+
+
+def test_homepage(page: Page):
+   page.goto("https://infinum.com/")
+
+   # Expect a title "to contain" a substring
+   expect(page).to_have_title(re.compile("Infinum"))
+
+   # Create a locator for button
+   accept_all_button = page.get_by_role("button", name="Accept all")
+
+   # Take a screenshot
+   page.screenshot(path="screenshot.png")
+
+   # Click the button
+   accept_all_button.click()
+
+   # Expect the button to be hidden
+   expect(accept_all_button).to_be_hidden()
+
+   # Take a full page screenshot (screenshot of a full scrollable page)
+   page.screenshot(path="screenshot_full_page.png", full_page=True)
+```
+
+### Resources
+
+* [Infinum QA handbook - Virtual environment](https://infinum.com/handbook/qa/automation/python/virtual-environment)
+* [Playwright for Python](https://playwright.dev/python/docs/intro)
+* [Playwright GitHub](https://github.com/microsoft/playwright)
+* [pytest-playwright plugin](https://pypi.org/project/pytest-playwright/)
+* [pytest](https://docs.pytest.org/en/7.2.x/) 

--- a/Automation/Web/Get started with Playwright for Python.md
+++ b/Automation/Web/Get started with Playwright for Python.md
@@ -16,18 +16,18 @@ This is a short and simple guide to quickly get started with Playwright for Pyth
 
 1. Create a new PyCharm project 
    * Create and activate a [virtual environment](https://infinum.com/handbook/qa/automation/python/virtual-environment)
-2. Install [pytest-playwright](https://pypi.org/project/pytest-playwright/) plugin 
+2. Install [pytest-playwright](https://pypi.org/project/pytest-playwright) plugin 
    * `pip install pytest-playwright`
 3. Install browsers 
    * `playwright install`
 4. Create a test file within the current working directory or a sub-directory
-   * File name e.g.: `test_homepage.py `
+   * File name e.g.: `test_homepage.py`
    * See example test below
 5. Run the test
    * On default (headless) browser:
      * `python3 -m pytest test_homepage.py`
    * On specific (headed) browser:
-     * `python3 -m pytest test_home_page.py --browser firefox –headed`
+     * `python3 -m pytest test_homepage.py --browser firefox --headed`
 
 
 ## Example
@@ -65,5 +65,5 @@ def test_homepage(page: Page):
 * [Infinum QA handbook - Virtual environment](https://infinum.com/handbook/qa/automation/python/virtual-environment)
 * [Playwright for Python](https://playwright.dev/python/docs/intro)
 * [Playwright GitHub](https://github.com/microsoft/playwright)
-* [pytest-playwright plugin](https://pypi.org/project/pytest-playwright/)
+* [pytest-playwright plugin](https://pypi.org/project/pytest-playwright)
 * [pytest](https://docs.pytest.org/en/7.2.x/) 

--- a/Automation/Web/Get started with Playwright for Python.md
+++ b/Automation/Web/Get started with Playwright for Python.md
@@ -1,7 +1,7 @@
 ## What is Playwright?
 
 Playwright is a test automation tool for Web testing. It supports testing on various browsers in both headed and headless mode. 
-You can write tests in JavaScript / TypeScript, C#, Java and Python. Depending on your language of choice, the setup slightly differs.
+You can write tests in JavaScript/TypeScript, C#, Java and Python. Depending on your language of choice, the setup slightly differs.
 
 This is a short and simple guide to quickly get started with Playwright for Python.
 
@@ -39,7 +39,7 @@ from playwright.sync_api import Page, expect
 
 
 def test_homepage(page: Page):
-   page.goto("https://infinum.com/")
+   page.goto("https://infinum.com")
 
    # Expect a title "to contain" a substring
    expect(page).to_have_title(re.compile("Infinum"))


### PR DESCRIPTION
Added a simple and short article with instructions for getting stared with Playwright for Python.
The setup is complete, it includes everything from the first step (installation) to the last one (successfully running the tests).

Much like the Puppeteer example, I would not go into more detail for now. We can expand on it later on when / needed.