### PR TITLE
Fix: identation in locator naming differences article

### DIFF
--- a/Automation/Mobile/Appium/Locator naming differences.md
+++ b/Automation/Mobile/Appium/Locator naming differences.md
@@ -5,6 +5,7 @@ There are some naming differences that add to the confusion when comparing Appiu
 To help with understanding, it is useful to use Appium Inspector to visualize the differences.
 
 Appium Inspector displays two useful sections on the right-hand side, Find By and Attribute.
+
 - **Find By** shows (some) locator strategies you could use to find the selected element, and the value it returns
 - **Attribute** provides information on the element's properties, and their corresponding values
 


### PR DESCRIPTION
Fixed indentation. Sections were not moved to a new line.